### PR TITLE
Chainability for the On method

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -134,6 +134,7 @@ var Api = function(id) {
 		if (readyFlag && event === 'ready') {
 			this.events.ready.trigger.apply(this);
 		}
+		return this;
 	};
 
 	this.off = function(event, func) {


### PR DESCRIPTION
It supposed to be able to write smth like this:

```
$(...).coverflow({
  ...
})
  .on('ready', function() { ... })
  .on('focus', function() { ... });
```

Added `return this` to the `on` method for chainability 
